### PR TITLE
Add ability to use variables in filenames

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -21,31 +21,33 @@ Index
 
 1. [Variables](variables)  
    Showing the use of `%{variables}`.
-2. [Import](import)  
+2. [Variables in Filenames](variables-in-filenames)  
+   Showing the use of `%{variables}` in filenames.
+3. [Import](import)  
    Showing the use of `@import`.
-3. [One to Many - Config from File](config-from-file)  
+4. [One to Many - Config from File](config-from-file)  
    Showing the use of the `kojo config` command to generate several output files from the same source template.
-4. [Many to Many - Config from Directory](config-from-dir)  
+5. [Many to Many - Config from Directory](config-from-dir)  
    Showing the use of the `kojo config` command to generate several output directories from the same source directory.
-5. [Other File Types](not-only-yaml)  
+6. [Other File Types](not-only-yaml)  
    Showing how kojo is used on other types of files.
-6. [Nested Import Commands](folder-nesting)  
+7. [Nested Import Commands](folder-nesting)  
    Showing how `@import` can be used to reference files in other folders.
-7. [Save to File](save-to-file)  
+8. [Save to File](save-to-file)  
    Showing how to save output to a file.
-8. [One to Many](save-to-folder-config)  
+9. [One to Many](save-to-folder-config)  
    Showing how to generate multiple files from a single source template using `kojo config`.
-9. [Cascading Variables](cascading-variables)  
+10. [Cascading Variables](cascading-variables)  
    Showing how variables are forwarded from top to bottom.
-10. [Compile Directory](dir)  
+11. [Compile Directory](dir)  
     Showing how to compile a directory of templates and create a similar output directory using `kojo dir`.
-11. [Compile Directory and Save](dir-save)  
+12. [Compile Directory and Save](dir-save)  
     Same as the `Compile Directory` example, but saving the output to a new directory.
-12. [Arguments from File - file command](argfile-file)  
+13. [Arguments from File - file command](argfile-file)  
     Showing how to provide arguments from a file to `kojo file`.
-13. [Arguments from File - config command](argfile-config)  
+14. [Arguments from File - config command](argfile-config)  
     Showing how to provide arguments from a file to `kojo config`.
-14. [Arguments from File - dir command](argfile-dir)  
+15. [Arguments from File - dir command](argfile-dir)  
     Showing how to provide arguments from a file to `kojo dir`.
-15. [ERB](erb)  
+16. [ERB](erb)  
     Showing how to use ERB for conditional output.

--- a/examples/variables-in-filenames/output.txt
+++ b/examples/variables-in-filenames/output.txt
@@ -1,0 +1,9 @@
++ kojo dir templates env=production app=hello replicas=2
+
+# hello-deployment.yml
+metadata:
+  name: hello
+  namespace: production
+
+spec:
+  replicas: 2

--- a/examples/variables-in-filenames/runme
+++ b/examples/variables-in-filenames/runme
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -x
+kojo dir templates env=production app=hello replicas=2

--- a/examples/variables-in-filenames/templates/%{app}-deployment.yml
+++ b/examples/variables-in-filenames/templates/%{app}-deployment.yml
@@ -1,0 +1,6 @@
+metadata:
+  name: %{app}
+  namespace: %{env}
+
+spec:
+  replicas: %{replicas}

--- a/lib/kojo/collection.rb
+++ b/lib/kojo/collection.rb
@@ -22,8 +22,8 @@ module Kojo
       template = Template.new file
       template.import_base = import_base
 
-      path = file.sub(/#{dir}\//, '')
-      
+      path = file.sub(/#{dir}\//, '') % args
+
       yield path, template.render(args)
     end
 

--- a/lib/kojo/template.rb
+++ b/lib/kojo/template.rb
@@ -58,7 +58,7 @@ module Kojo
         line.chomp!
         spaces = line[/^\s*/].size
 
-        if line =~ /@import ([^(\s]*)\s*(?:\((.*)\))?\s*/
+        if line =~ /^\s*@import ([^(\s]*)\s*(?:\((.*)\))?\s*/
           file = $1
           args = $2 || ''
           args = instance_eval("{#{args}}")

--- a/spec/fixtures/examples/stdout/variables-in-filenames
+++ b/spec/fixtures/examples/stdout/variables-in-filenames
@@ -1,0 +1,8 @@
+
+[0;32m# hello-deployment.yml
+[0mmetadata:
+  name: hello
+  namespace: production
+
+spec:
+  replicas: 2


### PR DESCRIPTION
- Add ability to use `%{variables}` in filenames
- Add example to show its use
- Update handling of `@import` statements so that they must be preceded by zero or more spaces only (to allow commenting out with `# @import filename`)