### PR TITLE
Add File.deep_write

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ end
 
 In addition, Kojo extends Ruby's `File` class with the `File.deep_write`
 method, which lets you write the file and create the directory structure as
-needed. You may use it in code like this:
+needed. You may use it in your code like this:
 
 ```ruby
 # Config

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Table of Contents
   - [Conditions and Loops with ERB](#conditions-and-loops-with-erb)
 - [Interactive Mode](#interactive-mode)
 - [Using from Ruby Code](#using-from-ruby-code)
+- [Contributing / Support](#contributing--support)
 
 ---
 
@@ -248,6 +249,24 @@ params = { version: '0.1.1' }
 result = template.render params do |path, content|
   # code to handle results here
 end
-
 ```
 
+In addition, Kojo extends Ruby's `File` class with the `File.deep_write`
+method, which lets you write the file and create the directory structure as
+needed. You may use it in code like this:
+
+```ruby
+# Config
+config = Kojo::Config.new 'examples/config-from-file/config.yml'
+config.import_base = "examples/config-from-file/imports"
+
+config.generate do |path, content|
+  File.deep_write path, content
+end
+```
+
+Contributing / Support
+--------------------------------------------------
+
+If you experience any issue, have a question or a suggestion, or if you wish
+to contribute, feel free to [open an issue][issues].

--- a/README.md
+++ b/README.md
@@ -270,3 +270,7 @@ Contributing / Support
 
 If you experience any issue, have a question or a suggestion, or if you wish
 to contribute, feel free to [open an issue][issues].
+
+---
+
+[issues]: https://github.com/DannyBen/kojo/issues

--- a/lib/kojo.rb
+++ b/lib/kojo.rb
@@ -2,6 +2,7 @@ require 'requires'
 require 'byebug' if ENV['BYEBUG']
 
 requires 'kojo/refinements'
+requires 'kojo/extensions'
 
 require 'kojo/exceptions'
 require 'kojo/template'

--- a/lib/kojo/commands/command_base.rb
+++ b/lib/kojo/commands/command_base.rb
@@ -5,9 +5,7 @@ module Kojo
     class CommandBase < MisterBin::Command
       def save(file, output)
         outpath = "#{outdir}/#{file}"
-        dir = File.dirname outpath
-        FileUtils.mkdir_p dir unless Dir.exist? dir
-        File.write outpath, output
+        File.deep_write outpath, output
         say "Saved #{outpath}"  
       end
     end

--- a/lib/kojo/extensions/file.rb
+++ b/lib/kojo/extensions/file.rb
@@ -1,0 +1,6 @@
+class File
+  def self.deep_write(path, content)
+    FileUtils.mkdir_p File.dirname(path)
+    File.write path, content
+  end
+end

--- a/spec/kojo/exceptions_spec.rb
+++ b/spec/kojo/exceptions_spec.rb
@@ -17,7 +17,7 @@ describe 'custom exceptions' do
   end
 
   it 'raise kojo errors' do
-    FileUtils.mkdir_p empty_dir unless Dir.exist? empty_dir
+    FileUtils.mkdir_p empty_dir
 
     cases.each do |name, command|
       puts "  --> #{name}"

--- a/spec/kojo/extensions/file_spec.rb
+++ b/spec/kojo/extensions/file_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe File do
+  describe '::deep_write' do
+    before do
+      system 'rm -rf tmp/deep'
+      expect(Dir).not_to exist('tmp/deep')
+    end
+
+    let(:file) { "tmp/deep/dish/file.txt" }
+
+    it "creates the directory structure and writes the file" do
+      File.deep_write file, "works"
+      expect(File).to exist(file)
+      expect(File.read file).to eq "works"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ require 'kojo/cli'
 include Kojo
 require_relative 'spec_mixin'
 
+system 'mkdir tmp' unless Dir.exist? 'tmp'
+
 # Consistent Colsole output (for rspec_fixtures)
 ENV['TTY'] = 'on'
 


### PR DESCRIPTION
Add `File.deep_write` so that users who are using Kojo as a library have easy means to write the yielded `|path, content|` iterations.