### PR TITLE
Update files collection to include dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ end
 template = Kojo::FrontMatterTemplate.new 'examples/single/Dockerfile'
 params = { version: '0.1.1' }
 
-result = template.render params do |path, content|
+template.render params do |path, content|
   # code to handle results here
 end
 ```

--- a/lib/kojo/collection.rb
+++ b/lib/kojo/collection.rb
@@ -38,7 +38,9 @@ module Kojo
       raise Kojo::NotFoundError, "Directory not found: #{dir}" unless Dir.exist? dir
       raise Kojo::NotFoundError, "Directory is empty: #{dir}" if Dir.empty? dir
 
-      @files = Dir["#{dir}/**/*"].reject { |f| File.directory? f }.sort
+      @files = Dir.glob("#{dir}/**/*", File::FNM_DOTMATCH)
+        .reject { |f| File.directory? f }
+        .sort
     end
   end
 end


### PR DESCRIPTION
When using Kojo with commands that work on directories, hidden files (dotfiles) were ignored.
This PR fixes it.