### PR TITLE
- Refactor file save to always use base function

### DIFF
--- a/lib/kojo/commands/command_base.rb
+++ b/lib/kojo/commands/command_base.rb
@@ -4,9 +4,8 @@ module Kojo
   module Commands
     class CommandBase < MisterBin::Command
       def save(file, output)
-        outpath = "#{outdir}/#{file}"
-        File.deep_write outpath, output
-        say "Saved #{outpath}"  
+        File.deep_write file, output
+        say "Saved #{file}"
       end
     end
   end

--- a/lib/kojo/commands/config.rb
+++ b/lib/kojo/commands/config.rb
@@ -3,7 +3,7 @@ require 'mister_bin'
 
 module Kojo::Commands
   # Handle calls to the +kojo config+ command
-  class ConfigCmd < MisterBin::Command
+  class ConfigCmd < CommandBase
     using Kojo::Refinements
 
     attr_reader :gen, :outdir, :opts, :import_base, :config_file
@@ -59,13 +59,5 @@ module Kojo::Commands
         say output
       end
     end
-
-    def save(path, output)
-      dir = File.dirname path
-      FileUtils.mkdir_p dir unless Dir.exist? dir
-      File.write path, output
-      say "Saved #{path}"
-    end
-
   end
 end

--- a/lib/kojo/commands/dir.rb
+++ b/lib/kojo/commands/dir.rb
@@ -62,7 +62,7 @@ module Kojo
 
       def write(collection)
         collection.render @opts do |file, output|
-          save file, output
+          save "#{outdir}/#{file}", output
         end
       end
     end

--- a/lib/kojo/commands/file.rb
+++ b/lib/kojo/commands/file.rb
@@ -3,7 +3,7 @@ require 'mister_bin'
 module Kojo
   module Commands
     # Handle calls to the +kojo file+ command
-    class FileCmd < MisterBin::Command
+    class FileCmd < CommandBase
       using Kojo::Refinements
 
       attr_reader :opts, :outfile, :infile, :import_base
@@ -48,8 +48,7 @@ module Kojo
         output = template.render(opts)
 
         if outfile
-          File.write outfile, output
-          say "Saved #{outfile}"
+          save outfile, output
         else
           puts output
         end

--- a/lib/kojo/commands/form.rb
+++ b/lib/kojo/commands/form.rb
@@ -24,8 +24,7 @@ module Kojo
         template = Kojo::Form.new infile
         
         if outfile
-          File.deep_write outfile, template.render
-          say "Saved #{outfile}"  
+          save outfile, template.render
         else
           puts template.render 
         end

--- a/lib/kojo/commands/single.rb
+++ b/lib/kojo/commands/single.rb
@@ -46,7 +46,7 @@ module Kojo
 
       def write(template)
         template.render opts do |file, output|
-          save file, output
+          save "#{outdir}/#{file}", output
         end
       end
     end

--- a/spec/kojo/commands/form_spec.rb
+++ b/spec/kojo/commands/form_spec.rb
@@ -22,19 +22,19 @@ describe Kojo::Commands::FormCmd do
     context "INFILE" do
       let(:args) { ['form', infile] }
 
-      it "delegates the INFILE to Kojo::Form", :focus do
+      it "delegates the INFILE to Kojo::Form" do
         expect(Kojo::Form).to receive(:new).with(infile).and_return(template)
         expect(template).to receive(:render)
         subject.execute args
       end
     end
 
-    context "INFILE --save FILE", :focus do
+    context "INFILE --save FILE" do
       let(:outfile) { 'tmp/form.md' }
       let(:args) { %W[form #{infile} --save #{outfile}] }
       before { File.delete outfile if File.exist? outfile }
 
-      it "prompts the user for input and saves the template" do
+      it "prompts the user for input and saves the template", :focus do
         expect(Kojo::Form).to receive(:new).with(infile).and_return(template)
         expect(template).to receive(:render).and_return('rendered')
         expect { subject.execute args }.to output("Saved #{outfile}\n").to_stdout


### PR DESCRIPTION
When writing to files, there were too many different methods. This PR normalizes all the cases to use `CommandBase#save`, which creates the directory structure as needed, writes the file, and outputs a "Saved file" message.