### PR TITLE
Add support for multiline @imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,15 @@ resulting configuration file.
 @import filename (arg: "value", arg2: "value")
 ```
 
-The space after `filename` is optional.
+The space after `filename` is optional, and the arguments list can be split to
+multiple lines:
+
+```ruby
+@import filename (
+  arg: "value",
+  arg2: "value"
+)
+```
 
 ### Transform an Entire Folder
 

--- a/examples/import-multiline/Dockerfile
+++ b/examples/import-multiline/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine
+
+@import base
+
+ENV ENVIRONMENT %{env}
+
+@import packages ( packages: "curl wget" )
+
+EXPOSE 3000
+
+@import command (
+  region: "us",
+  host: "example.com"
+)
+

--- a/examples/import-multiline/Dockerfile
+++ b/examples/import-multiline/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-@import base
+@import base   
 
 ENV ENVIRONMENT %{env}
 
@@ -13,3 +13,4 @@ EXPOSE 3000
   host: "example.com"
 )
 
+# Done

--- a/examples/import-multiline/base
+++ b/examples/import-multiline/base
@@ -1,0 +1,2 @@
+# base file
+ENV DEBUG 1

--- a/examples/import-multiline/command
+++ b/examples/import-multiline/command
@@ -1,0 +1,2 @@
+# command file
+CMD start-the-server --region %{region} --host %{host}

--- a/examples/import-multiline/packages
+++ b/examples/import-multiline/packages
@@ -1,0 +1,2 @@
+# packages file
+RUN apk add %{packages}

--- a/examples/import-multiline/runme
+++ b/examples/import-multiline/runme
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -x
+kojo file Dockerfile env=production

--- a/lib/kojo/refinements/string.rb
+++ b/lib/kojo/refinements/string.rb
@@ -47,7 +47,7 @@ module Kojo
       end
 
       def compress_imports
-        gsub /^ *@import [^(\s]*\s*\([^)]+\)$/ do |match|
+        gsub /^ *@import +[^(\s]+\s*\([\S\s]*?\) *$/ do |match|
           match.gsub /\r?\n\s*/, " "
         end
       end

--- a/lib/kojo/refinements/string.rb
+++ b/lib/kojo/refinements/string.rb
@@ -48,7 +48,7 @@ module Kojo
 
       def compress_imports
         gsub /^\s*@import [^(\s]*\s*\([^)]+\)\s*$/ do |match|
-          match.gsub /\r?\n\r?\s*/, " "
+          match.gsub /\r?\n\s*/, " "
         end
       end
 

--- a/lib/kojo/refinements/string.rb
+++ b/lib/kojo/refinements/string.rb
@@ -46,6 +46,12 @@ module Kojo
         raise Kojo::TemplateError, "#{e.message}\nin: #{filename}"
       end
 
+      def compress_imports
+        gsub /^\s*@import [^(\s]*\s*\([^)]+\)\s*$/ do |match|
+          match.gsub /\r?\n\r?\s*/, " "
+        end
+      end
+
     private 
 
       def get_user_input

--- a/lib/kojo/refinements/string.rb
+++ b/lib/kojo/refinements/string.rb
@@ -47,7 +47,7 @@ module Kojo
       end
 
       def compress_imports
-        gsub /^\s*@import [^(\s]*\s*\([^)]+\)\s*$/ do |match|
+        gsub /^ *@import [^(\s]*\s*\([^)]+\)$/ do |match|
           match.gsub /\r?\n\s*/, " "
         end
       end

--- a/lib/kojo/template.rb
+++ b/lib/kojo/template.rb
@@ -38,8 +38,8 @@ module Kojo
 
     def eval_imports(content)
       result = []
-      
-      content.lines.each do |line|
+
+      content.compress_imports.lines.each do |line|
         line.chomp!
         spaces = line[/^\s*/].size
 

--- a/spec/approvals/examples/stdout/import-multiline
+++ b/spec/approvals/examples/stdout/import-multiline
@@ -1,0 +1,14 @@
+FROM alpine
+
+# base file
+ENV DEBUG 1
+
+ENV ENVIRONMENT production
+
+# packages file
+RUN apk add curl wget
+
+EXPOSE 3000
+
+# command file
+CMD start-the-server --region us --host example.com

--- a/spec/approvals/examples/stdout/import-multiline
+++ b/spec/approvals/examples/stdout/import-multiline
@@ -12,3 +12,5 @@ EXPOSE 3000
 
 # command file
 CMD start-the-server --region us --host example.com
+
+# Done


### PR DESCRIPTION
- [x] Implementation
- [x] Tests
- [x] Example
- [x] Docs

Adds the ability to split the `@import` arguments to multiple lines, like so:

```
@import file (
  arg1: "yes",
  arg2: "maybe"
)
```

Closes #40 