### PR TITLE
Fix Ruby 3.1 compatibility and drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: ['2.5', '2.6', '2.7', '3.0'] }
+      matrix: { ruby: ['2.6', '2.7', '3.0', '3.1'] }
 
     steps:
     - name: Checkout code

--- a/kojo.gemspec
+++ b/kojo.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables = Dir['bin/kojo*'].map { |f| File.basename f }
   s.homepage    = 'https://github.com/dannyben/kojo'
   s.license     = 'MIT'
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.6.0"
 
   s.add_runtime_dependency 'mister_bin', '~> 0.6'
   s.add_runtime_dependency 'requires', '~> 0.1'

--- a/lib/kojo.rb
+++ b/lib/kojo.rb
@@ -4,8 +4,8 @@ require 'byebug' if ENV['BYEBUG']
 require 'yaml'
 require 'json'
 
-requires 'kojo/refinements'
 requires 'kojo/extensions'
+requires 'kojo/refinements'
 
 require 'kojo/exceptions'
 require 'kojo/template'

--- a/lib/kojo/commands/config.rb
+++ b/lib/kojo/commands/config.rb
@@ -33,7 +33,7 @@ module Kojo::Commands
       argfile = args['--args']
 
       if argfile
-        fileopts = YAML.load_file(argfile).symbolize_keys
+        fileopts = YAML.properly_load_file(argfile).symbolize_keys
         @opts = fileopts.merge opts
       end
 

--- a/lib/kojo/commands/dir.rb
+++ b/lib/kojo/commands/dir.rb
@@ -33,7 +33,7 @@ module Kojo
         argfile = args['--args']
 
         if argfile
-          fileopts = YAML.load_file(argfile).symbolize_keys
+          fileopts = YAML.properly_load_file(argfile).symbolize_keys
           @opts = fileopts.merge @opts
         end
 

--- a/lib/kojo/commands/file.rb
+++ b/lib/kojo/commands/file.rb
@@ -33,7 +33,7 @@ module Kojo
         argfile = args['--args']
 
         if argfile
-          fileopts = YAML.load_file(argfile).symbolize_keys
+          fileopts = YAML.properly_load_file(argfile).symbolize_keys
           @opts = fileopts.merge opts
         end
 

--- a/lib/kojo/commands/to_json.rb
+++ b/lib/kojo/commands/to_json.rb
@@ -35,7 +35,7 @@ module Kojo
     private
 
       def tojson(path)
-        JSON.pretty_generate YAML.load_file(path)
+        JSON.pretty_generate YAML.properly_load_file(path)
       end
 
       # Glob patterns are usually handled by the shell, but in case

--- a/lib/kojo/config.rb
+++ b/lib/kojo/config.rb
@@ -59,7 +59,7 @@ module Kojo
     end
 
     def config
-      @config ||= YAML.load_file config_file
+      @config ||= YAML.properly_load_file config_file
     end
   end
 

--- a/lib/kojo/extensions/yaml.rb
+++ b/lib/kojo/extensions/yaml.rb
@@ -1,0 +1,10 @@
+require 'yaml'
+
+module YAML
+  # ref: https://bugs.ruby-lang.org/issues/17866
+  def self.properly_load_file(path)
+    YAML.load_file path, aliases: true
+  rescue ArgumentError
+    YAML.load_file path
+  end
+end

--- a/lib/kojo/front_matter_template.rb
+++ b/lib/kojo/front_matter_template.rb
@@ -32,7 +32,7 @@ module Kojo
     def read_file(file)
       raise Kojo::NotFoundError, "File not found: #{file}" unless File.exist? file
 
-      config = YAML.load_file file
+      config = YAML.properly_load_file file
       content = File.read(file)[/^---\s*$\n(.*)/m, 1]
 
       [config, content]

--- a/lib/kojo/refinements/string.rb
+++ b/lib/kojo/refinements/string.rb
@@ -57,7 +57,7 @@ module Kojo
       end
 
       def erb(template, vars)
-        ERB.new(template, nil, '-').result(OpenStruct.new(vars).instance_eval { binding })
+        ERB.new(template, trim_mode: '-').result(OpenStruct.new(vars).instance_eval { binding })
       end
 
     end

--- a/spec/kojo/extensions/yaml_spec.rb
+++ b/spec/kojo/extensions/yaml_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe YAML do
+  describe '::properly_load_file' do
+    let(:file) { "spec/samples/anchors.yml" }
+    subject { YAML.properly_load_file(file) }
+
+    it "loads files with anchors" do
+      expect(subject['other']).to eq ["one", "two"]
+    end
+  end
+end

--- a/spec/samples/anchors.yml
+++ b/spec/samples/anchors.yml
@@ -1,0 +1,4 @@
+list: &default
+- one
+- two
+other: *default


### PR DESCRIPTION
Changes in `ERB.new` syntax, and in `YAML.load_file` behavior required updates here.

The new ERB.new syntax is not supported in Ruby < 2.6.